### PR TITLE
add django admin register

### DIFF
--- a/django_neomodel/admin.py
+++ b/django_neomodel/admin.py
@@ -1,0 +1,4 @@
+from django.contrib import admin
+
+def register(model, model_admin):
+	admin.site.register([model], model_admin)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.sites',
+    'django.contrib.staticfiles',
 
     # Third party
     'django_neomodel',
@@ -68,6 +69,9 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
+
+STATIC_ROOT = "./static/"
+STATIC_URL = '/static/'
 
 DJANGO_SUPERUSER_PASSWORD = "1234"
 DJANGO_SUPERUSER_EMAIL = "example@example.com"

--- a/tests/someapp/admin.py
+++ b/tests/someapp/admin.py
@@ -1,12 +1,21 @@
-from django.contrib import admin
+from django.contrib import admin as dj_admin
+from django_neomodel import admin as neo_admin
+from .models import Library, Book, Shelf
 
-from .models import Library
 
-
-@admin.register(Library)
-class LibraryAdmin(admin.ModelAdmin):
+class LibraryAdmin(dj_admin.ModelAdmin):
     list_display = (
         "id",
         "name",
     )
+dj_admin.site.register(Library, LibraryAdmin)
 
+
+class BookAdmin(dj_admin.ModelAdmin):
+    list_display = ("title", "created")
+neo_admin.register(Book, BookAdmin)
+
+
+class ShelfAdmin(dj_admin.ModelAdmin):
+    list_display = ("name",)
+neo_admin.register(Shelf, ShelfAdmin)

--- a/tests/someapp/models.py
+++ b/tests/someapp/models.py
@@ -13,7 +13,7 @@ class Library(models.Model):
 
 
 class Book(DjangoNode):
-    uid = UniqueIdProperty()
+    uid = UniqueIdProperty(primary_key=True)
     title = StringProperty(unique_index=True)
     format = StringProperty(required=True)  # check required field can be omitted on update
     status = StringProperty(choices=(
@@ -24,4 +24,18 @@ class Book(DjangoNode):
     created = DateTimeProperty(default=datetime.utcnow)
 
     class Meta:
-        app_label = 'someapp'
+        app_label = "someapp"
+
+    def __str__(self):
+        return self.title
+
+
+class Shelf(DjangoNode):
+    uid = UniqueIdProperty(primary_key=True)
+    name = StringProperty()
+
+    class Meta:
+        app_label = "someapp"
+
+    def __str__(self):
+        return self.name

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
 from django.contrib import admin
+from django.conf import settings
+from django.conf.urls.static import static
 
 
-urlpatterns = [url(r"^admin/", admin.site.urls)]
+urlpatterns = [url(r"^admin/", admin.site.urls)] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
How to test:

First make sure you have the Neo4j Desktop running with 1 database then 

```
# create local venv and install dependencies.
$ python3 -m venv venv; source venv/bin/activate; python setup.py develop; export DJANGO_SETTINGS_MODULE=settings; export NEO4J_BOLT_URL=bolt://neo4j:123456@localhost:7687
# Go to tests
$ cd tests/
$ pip install -r requirements.txt
$ ./manage.py install_labels
$ ./manage.py migrate
$ ./manage.py createsuperuser
$ pytest # this will populate the database with a few test books
$ ./manage.py runserver
```
You should be able to go to http://localhost:8000/admin/someapp/book/ and see a list of the nodes in your neo4j database.