### PR TITLE
add commands for removal & update of labels

### DIFF
--- a/django_neomodel/management/commands/_remove_labels.py
+++ b/django_neomodel/management/commands/_remove_labels.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-from neomodel import drop_indexes, db
+from neomodel import db
 
 def drop_constraints(quiet=True, stdout=None):
     """

--- a/django_neomodel/management/commands/_remove_labels.py
+++ b/django_neomodel/management/commands/_remove_labels.py
@@ -1,0 +1,67 @@
+import re
+import sys
+
+from neomodel import drop_indexes, db
+
+def drop_constraints(quiet=True, stdout=None):
+    """
+    Discover and drop all constraints.
+
+    :type: bool
+    :return: None
+    """
+
+    results, meta = db.cypher_query("CALL db.constraints()")
+    pattern = re.compile(':(.*) \).*\.(\w*)')   # Pattern for matching label and property in query 
+    for (constr_name, constr_query, _constr_obj) in results:
+        db.cypher_query('DROP CONSTRAINT ' + constr_name)
+        match = pattern.search(constr_query)
+        stdout.write(''' - Droping unique constraint and index on label {0} with property {1}.\n'''.format(
+            match.group(1), match.group(2)))
+    stdout.write("\n")
+
+
+def remove_all_labels(stdout=None):
+    """
+    Calls functions for dropping constraints and indexes.
+
+    :param stdout: output stream
+    :return: None
+    """
+
+    if not stdout:
+        stdout = sys.stdout
+
+    stdout.write("Droping constraints...\n")
+    drop_constraints(quiet=False, stdout=stdout)
+
+    stdout.write('Droping indexes...\n')
+    drop_indexes(quiet=False, stdout=stdout)
+
+
+def drop_indexes(quiet=True, stdout=None):
+    """
+    Discover and drop all indexes.
+
+    :type: bool
+    :return: None
+    """
+
+    results, meta = db.cypher_query("CALL db.indexes()")
+    for index in results:
+        idx_name = index[1]
+        db.cypher_query('DROP INDEX ' + index[1])
+
+        idx_label = index[7]
+        idx_property = index[8]
+        if not idx_property:
+            if not idx_label:
+                stdout.write(' - Dropping index without label and without property.\n')
+            else:
+                stdout.write(' - Dropping index on label {0} without property.\n'.format(
+                    idx_label))
+        else:
+            stdout.write(' - Dropping index on label {0} with property {1}.\n'.format(
+                idx_label, idx_property))
+    stdout.write("\n")
+

--- a/django_neomodel/management/commands/remove_labels.py
+++ b/django_neomodel/management/commands/remove_labels.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from ._remove_labels import remove_all_labels
+
+
+
+class Command(BaseCommand):
+    help = 'Install labels and constraints for your neo4j database'
+
+    def handle(self, *args, **options):
+        remove_all_labels(stdout=self.stdout)
+
+

--- a/django_neomodel/management/commands/update_labels.py
+++ b/django_neomodel/management/commands/update_labels.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from ._remove_labels import remove_all_labels
+from neomodel import install_all_labels
+
+
+
+class Command(BaseCommand):
+    help = 'Install labels and constraints for your neo4j database'
+
+    def handle(self, *args, **options):
+        remove_all_labels()
+        install_all_labels()
+
+
+


### PR DESCRIPTION
Adds commands for removal and update of labels to Djangos manage.py.

Currently running install_labels fails if an equivalent constraints were already defined. Addresses #58 .

`neomodel.remove_all_labels` fails without the additions in `_remove_labels.py`. The APIs seem to have diverged. 