### PR TITLE
Update pyproject.toml for >= Django 2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "neomodel~=5.0.0",
-    'django~=2.2'
+    'django>=2.2'
 ]
 version='0.1.0'
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
 
 
-urlpatterns = [url(r"^admin/", admin.site.urls)] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns = [re_path(r"^admin/", admin.site.urls)] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
- Update urls.py to re_path (Removed in Django 4.0)

- Fixes where django would be downgraded to Django 2.2 when attempting to use in Django 3.0+ projects ([!84](https://github.com/neo4j-contrib/django-neomodel/issues/84) & [!85](https://github.com/neo4j-contrib/django-neomodel/issues/85))
