### PR TITLE
Python 3.12 support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,13 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.10", "3.9", "3.8", "3.7"]
+        python-version: ["3.12", "3.11", "3.10", "3.9", "3.8", "3.7"]
         neo4j-version: ["community", "4.4-community"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Creating Neo4j Container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Database",
 ]
 dependencies = [
-    "neomodel~=5.1.0",
+    "neomodel~=5.2.0",
     'django>=2.2'
 ]
 version='0.1.1'


### PR DESCRIPTION
Neomodel < 5.2 install fails on Python 3.12. However, Neomodel >= 5.2.0 works with all Python versions specified in CI.